### PR TITLE
THES-463: Update asset with new data

### DIFF
--- a/pbsmmapi/changelog/tasks.py
+++ b/pbsmmapi/changelog/tasks.py
@@ -217,8 +217,10 @@ def reingest_updated_objects():
     ):
         changelog = ChangeLog.objects.get(content_id=item.object_id)
         if changelog.latest_timestamp > item.date_last_api_update:
-            data = changelog.api_data["data"]
-            Asset.set(data, last_api_status=changelog.api_status)
+            _, data = get_PBSMM_record(
+                changelog.api_url
+            )  # actually get latest changelog data
+            Asset.set(data["api_data"], last_api_status=changelog.api_status)
 
     # Under some circumstances, an Asset can be updated without the change
     # being reflected by the parent object's ChangeLog.

--- a/pbsmmapi/changelog/tasks.py
+++ b/pbsmmapi/changelog/tasks.py
@@ -220,7 +220,7 @@ def reingest_updated_objects():
             _, data = get_PBSMM_record(
                 changelog.api_url
             )  # actually get latest changelog data
-            Asset.set(data["api_data"], last_api_status=changelog.api_status)
+            Asset.set(data["data"], last_api_status=changelog.api_status)
 
     # Under some circumstances, an Asset can be updated without the change
     # being reflected by the parent object's ChangeLog.


### PR DESCRIPTION
Other pbsmmapi models hit the Media Manager API again when they call the save() method in this Huey task, but Asset does not have one - it only has the set method to update fields. 

Because we're refactoring this part of the code with the RC branch I'll just do a quick, relatively lazy way to update assets when new changelogs are detected for an existing asset.